### PR TITLE
Generalize overview export

### DIFF
--- a/lib/public/models/OverviewExportModel.js
+++ b/lib/public/models/OverviewExportModel.js
@@ -1,0 +1,163 @@
+/**
+ * @license
+ * Copyright CERN and copyright holders of ALICE O2. This software is
+ * distributed under the terms of the GNU General Public License v3 (GPL
+ * Version 3), copied verbatim in the file "COPYING".
+ *
+ * See http://alice-o2.web.cern.ch/license for full licensing information.
+ *
+ * In applying this license CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+ */
+
+import { Observable } from '/js/src/index.js';
+import { RemoteData } from '/js/src/index.js';
+import { ObservableData } from '../utilities/ObservableData.js';
+import { createCSVExport, createJSONExport } from '../utilities/export.js';
+import pick from '../utilities/pick.js';
+
+/**
+ * Model handling export configuration and creation
+ */
+export class OverviewExportModel extends Observable {
+    /**
+     * @param {ObservableData<RemoteData<Object[]>>} [items$] observable data used as source for export
+     */
+    constructor(items$ = ObservableData.builder().initialValue(RemoteData.notAsked()).build()) {
+        super();
+
+        /** @type {ObservableData<RemoteData<Object[]>>} */
+        this._items$ = items$;
+        /** @type {string[]} */
+        this._selectedFields = [];
+        /** @type {string} */
+        this._selectedExportType = 'JSON';
+        /** @type {Observable} */
+        this._visualChange$ = new Observable();
+    }
+
+    /**
+     * Set the observable data used as source of items to export
+     * @param {ObservableData<RemoteData<Object[]>>} items$
+     * @return {void}
+     */
+    setItemsSource(items$) {
+        this._items$ = items$;
+    }
+
+    /**
+     * Observable notified when the export configuration visually changes
+     * @return {Observable}
+     */
+    get visualChange$() {
+        return this._visualChange$;
+    }
+
+    /**
+     * Get export type selected by the user
+     * @return {string} export type
+     */
+    getSelectedExportType() {
+        return this._selectedExportType;
+    }
+
+    /**
+     * Set export type
+     * @param {string} exportType export type
+     * @return {void}
+     */
+    setSelectedExportType(exportType) {
+        this._selectedExportType = exportType;
+        this.notify();
+        this._visualChange$.notify();
+    }
+
+    /**
+     * Get selected fields
+     * @return {string[]} selected fields
+     */
+    getSelectedFields() {
+        return this._selectedFields;
+    }
+
+    /**
+     * Update selected fields from HTML options list
+     * @param {HTMLCollection|Array} selectedOptions options collection
+     * @return {void}
+     */
+    setSelectedFields(selectedOptions) {
+        this._selectedFields = [];
+        [...selectedOptions].forEach(({ value }) => this._selectedFields.push(value));
+        this.notify();
+        this._visualChange$.notify();
+    }
+
+    /**
+     * Create export using current items observable
+     * @param {string} fileName base file name
+     * @param {Object<string, *>} exportFormats export configuration per field
+     * @param {function(RemoteData):void} [setError] callback for setting error
+     * @return {Promise<void>} void
+     */
+    async createExport(fileName, exportFormats, setError) {
+        const itemsRemoteData = this._items$.getCurrent();
+        const items = itemsRemoteData.isSuccess() ? itemsRemoteData.payload : [];
+
+        if (!itemsRemoteData.isSuccess() || items.length === 0) {
+            if (setError) {
+                setError(RemoteData.failure([
+                    {
+                        title: 'No data found',
+                        detail: 'No items were found with the provided filters',
+                    },
+                ]));
+            }
+            this.notify();
+            return;
+        }
+
+        const selectedFields = this.getSelectedFields() || [];
+
+        const detectors = new Set();
+        for (const item of items) {
+            item.qcFlags?.forEach(({ detector }) => {
+                if (detector?.name) {
+                    detectors.add(detector.name);
+                }
+            });
+        }
+
+        const formatted = items.map((item) => {
+            const entries = Object.entries(pick(item, selectedFields));
+            const mapped = entries.map(([key, value]) => {
+                const formatter = exportFormats[key]?.exportFormat || ((v) => v);
+                return [key, formatter(value, item)];
+            });
+
+            const perDetectorFlags = {};
+            item.qcFlags?.forEach(({ detector, flagType, from, to }) => {
+                const detName = detector?.name;
+                if (!detName) {
+                    return;
+                }
+                const text = `${flagType?.name ?? ''} ( from: ${from} to: ${to} )`;
+                if (!perDetectorFlags[detName]) {
+                    perDetectorFlags[detName] = [];
+                }
+                perDetectorFlags[detName].push(text);
+            });
+            for (const det of detectors) {
+                mapped.push([det, (perDetectorFlags[det] || []).join('|')]);
+            }
+
+            return Object.fromEntries(mapped);
+        });
+
+        this.getSelectedExportType() === 'CSV'
+            ? createCSVExport(formatted, `${fileName}.csv`, 'text/csv;charset=utf-8;')
+            : createJSONExport(formatted, `${fileName}.json`, 'application/json');
+    }
+}
+
+

--- a/lib/public/models/OverviewModel.js
+++ b/lib/public/models/OverviewModel.js
@@ -16,6 +16,7 @@ import { ObservableData } from '../utilities/ObservableData.js';
 import { PaginatedRemoteDataSource } from '../utilities/fetch/PaginatedRemoteDataSource.js';
 import { PaginationModel } from '../components/Pagination/PaginationModel.js';
 import { SortModel } from '../components/common/table/SortModel.js';
+import { OverviewExportModel } from './OverviewExportModel.js';
 
 /**
  * Interface of a model representing an overview page state
@@ -66,6 +67,9 @@ export class OverviewPageModel extends Observable {
             horizontalScrollEnabled: false,
             freezeFirstColumn: false,
         });
+
+        this.exportModel = new OverviewExportModel(this._observableItems);
+        this.exportModel.bubbleTo(this);
     }
 
     /**
@@ -191,6 +195,7 @@ export class OverviewPageModel extends Observable {
     get displayOptions() {
         return this._displayOptions.getCurrent();
     }
+
 
     /**
      * Returns the model handling the overview page table sort

--- a/lib/public/models/RunsPerDataPassExportModel.js
+++ b/lib/public/models/RunsPerDataPassExportModel.js
@@ -1,0 +1,142 @@
+/**
+ * @license
+ * Copyright CERN and copyright holders of ALICE O2. This software is
+ * distributed under the terms of the GNU General Public License v3 (GPL
+ * Version 3), copied verbatim in the file "COPYING".
+ *
+ * See http://alice-o2.web.cern.ch/license for full licensing information.
+ *
+ * In applying this license CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+ */
+
+import { buildUrl, RemoteData } from '/js/src/index.js';
+import { getRemoteDataSlice } from '../utilities/fetch/getRemoteDataSlice.js';
+import { OverviewExportModel } from './OverviewExportModel.js';
+import { createCSVExport, createJSONExport } from '../utilities/export.js';
+import pick from '../utilities/pick.js';
+
+/**
+ * Export model specialized for runs per data pass overview
+ */
+export class RunsPerDataPassExportModel extends OverviewExportModel {
+    /**
+     * @param {ObservableData<RemoteData<Object[]>>} items$ source items
+     * @param {number} [dataPassId] data pass id
+     */
+    constructor(items$, dataPassId) {
+        super(items$);
+        this._dataPassId = dataPassId;
+    }
+
+    /**
+     * Set data pass id used to fetch QC flags
+     * @param {number} dataPassId data pass id
+     * @return {void}
+     */
+    setDataPassId(dataPassId) {
+        this._dataPassId = dataPassId;
+    }
+
+    /**
+     * Fetch QC flags for given runs
+     * @param {number[]} runNumbers run numbers
+     * @return {Promise<Object<number, Object[]>>} map of run number to flags
+     * @private
+     */
+    async _fetchQcFlags(runNumbers) {
+        const map = {};
+        for (const runNumber of runNumbers) {
+            try {
+                const { items } = await getRemoteDataSlice(buildUrl('/api/qcFlags/perDataPass', {
+                    dataPassId: this._dataPassId,
+                    runNumber,
+                    'page[limit]': 1000,
+                }));
+                map[runNumber] = items;
+            } catch (_) {
+                map[runNumber] = [];
+            }
+        }
+        return map;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    async createExport(fileName, exportFormats, setError) {
+        const itemsRemoteData = this._items$.getCurrent();
+        const items = itemsRemoteData.isSuccess() ? itemsRemoteData.payload : [];
+
+        if (!itemsRemoteData.isSuccess() || items.length === 0) {
+            if (setError) {
+                setError(RemoteData.failure([
+                    {
+                        title: 'No data found',
+                        detail: 'No items were found with the provided filters',
+                    },
+                ]));
+            }
+            this.notify();
+            return;
+        }
+
+        let itemsWithFlags = items;
+        if (this._dataPassId) {
+            try {
+                const qcMap = await this._fetchQcFlags(items.map(({ runNumber }) => runNumber));
+                itemsWithFlags = items.map((run) => ({ ...run, qcFlags: qcMap[run.runNumber] || [] }));
+            } catch (_) {
+                if (setError) {
+                    setError(RemoteData.failure([
+                        { title: 'QC flags fetch failed', detail: 'Unable to fetch QC flags for export' },
+                    ]));
+                }
+                return;
+            }
+        }
+
+        const selectedFields = this.getSelectedFields() || [];
+
+        const detectors = new Set();
+        for (const item of itemsWithFlags) {
+            item.qcFlags?.forEach(({ detector }) => {
+                if (detector?.name) {
+                    detectors.add(detector.name);
+                }
+            });
+        }
+
+        const formatted = itemsWithFlags.map((item) => {
+            const entries = Object.entries(pick(item, selectedFields));
+            const mapped = entries.map(([key, value]) => {
+                const formatter = exportFormats[key]?.exportFormat || ((v) => v);
+                return [key, formatter(value, item)];
+            });
+
+            const perDetectorFlags = {};
+            item.qcFlags?.forEach(({ detector, flagType, from, to }) => {
+                const detName = detector?.name;
+                if (!detName) {
+                    return;
+                }
+                const text = `${flagType?.name ?? ''} ( from: ${from} to: ${to} )`;
+                if (!perDetectorFlags[detName]) {
+                    perDetectorFlags[detName] = [];
+                }
+                perDetectorFlags[detName].push(text);
+            });
+            for (const det of detectors) {
+                mapped.push([det, (perDetectorFlags[det] || []).join('|')]);
+            }
+
+            return Object.fromEntries(mapped);
+        });
+
+        this.getSelectedExportType() === 'CSV'
+            ? createCSVExport(formatted, `${fileName}.csv`, 'text/csv;charset=utf-8;')
+            : createJSONExport(formatted, `${fileName}.json`, 'application/json');
+    }
+}
+

--- a/lib/public/views/Runs/ActiveColumns/runsActiveColumns.js
+++ b/lib/public/views/Runs/ActiveColumns/runsActiveColumns.js
@@ -667,4 +667,31 @@ export const runsActiveColumns = {
         ),
         profiles: ['runsPerLhcPeriod', 'runsPerDataPass', 'runsPerSimulationPass', profiles.none],
     },
+    fillingSchemeName: {
+        name: 'Filling Scheme',
+        visible: false,
+        exportFormat: (scheme) => scheme ?? '-',
+    },
+    collidingBunchesCount: {
+        name: 'Colliding Bunches',
+        visible: false,
+    },
+    muInelasticInteractionRate: {
+        name: 'μ(INEL)',
+        visible: false,
+    },
+    inelasticInteractionRateAvg: {
+        name: 'INEL Avg (Hz)',
+        visible: false,
+    },
+    readyForSkimming: {
+        name: 'Ready for Skimming',
+        visible: false,
+        exportFormat: (value) => value === true ? 'yes' : value === false ? 'no' : '-',
+    },
+    readyForDeletion: {
+        name: 'Ready for Deletion',
+        visible: false,
+        exportFormat: (value) => value === true ? 'yes' : value === false ? 'no' : '-',
+    },
 };

--- a/lib/public/views/Runs/Overview/RunsOverviewModel.js
+++ b/lib/public/views/Runs/Overview/RunsOverviewModel.js
@@ -12,13 +12,12 @@
  */
 
 import { buildUrl, RemoteData } from '/js/src/index.js';
-import { createCSVExport, createJSONExport } from '../../../utilities/export.js';
+import { ObservableData } from '../../../utilities/ObservableData.js';
 import { TagFilterModel } from '../../../components/Filters/common/TagFilterModel.js';
 import { debounce } from '../../../utilities/debounce.js';
 import { DetectorsFilterModel } from '../../../components/Filters/RunsFilter/DetectorsFilterModel.js';
 import { RunTypesFilterModel } from '../../../components/runTypes/RunTypesFilterModel.js';
 import { EorReasonFilterModel } from '../../../components/Filters/RunsFilter/EorReasonFilterModel.js';
-import pick from '../../../utilities/pick.js';
 import { OverviewPageModel } from '../../../models/OverviewModel.js';
 import { getRemoteDataSlice } from '../../../utilities/fetch/getRemoteDataSlice.js';
 import { CombinationOperator } from '../../../components/Filters/common/CombinationOperatorChoiceModel.js';
@@ -94,7 +93,8 @@ export class RunsOverviewModel extends OverviewPageModel {
         this._filteringModel.visualChange$.bubbleTo(this);
 
         // Export items
-        this._allRuns = RemoteData.NotAsked();
+        this._allRuns$ = new ObservableData(RemoteData.notAsked());
+        this.exportModel.setItemsSource(this._allRuns$);
 
         this.reset(false);
         const updateDebounceTime = () => {
@@ -115,58 +115,10 @@ export class RunsOverviewModel extends OverviewPageModel {
      * @inheritdoc
      */
     async load() {
-        this._allRuns = RemoteData.NotAsked();
+        this._allRuns$.setCurrent(RemoteData.notAsked());
         super.load();
     }
 
-    /**
-     * Create the export with the variables set in the model, handling errors appropriately
-     * @param {object[]} runs The source content.
-     * @param {string} fileName The name of the file including the output format.
-     * @param {Object<string, Function<*, string>>} exportFormats defines how particular fields of data units will be formated
-     * @return {void}
-     */
-    async createRunsExport(runs, fileName, exportFormats) {
-        if (runs.length > 0) {
-            const selectedRunsFields = this.getSelectedRunsFields() || [];
-            runs = runs.map((selectedRun) => {
-                const entries = Object.entries(pick(selectedRun, selectedRunsFields));
-                const formattedEntries = entries.map(([key, value]) => {
-                    const formatExport = exportFormats[key].exportFormat || ((identity) => identity);
-                    return [key, formatExport(value, selectedRun)];
-                });
-                return Object.fromEntries(formattedEntries);
-            });
-            this.getSelectedExportType() === 'CSV'
-                ? createCSVExport(runs, `${fileName}.csv`, 'text/csv;charset=utf-8;')
-                : createJSONExport(runs, `${fileName}.json`, 'application/json');
-        } else {
-            this._observableItems.setCurrent(RemoteData.failure([
-                {
-                    title: 'No data found',
-                    detail: 'No valid runs were found for provided run number(s)',
-                },
-            ]));
-            this.notify();
-        }
-    }
-
-    /**
-     * Get the field values that will be exported
-     * @return {Array} the field objects of the current export being created
-     */
-    getSelectedRunsFields() {
-        return this.selectedRunsFields;
-    }
-
-    /**
-     * Get the output format of the export
-     *
-     * @return {string} the output format
-     */
-    getSelectedExportType() {
-        return this.selectedExportType;
-    }
 
     /**
      * Returns all filtering, sorting and pagination settings to their default values
@@ -220,28 +172,6 @@ export class RunsOverviewModel extends OverviewPageModel {
         return this._filteringModel;
     }
 
-    /**
-     * Set the export type parameter of the current export being created
-     * @param {string} selectedExportType Received string from the view
-     * @return {void}
-     */
-    setSelectedExportType(selectedExportType) {
-        this.selectedExportType = selectedExportType;
-        this.notify();
-    }
-
-    /**
-     * Updates the selected fields ID array according to the HTML attributes of the options
-     *
-     * @param {HTMLCollection} selectedOptions The currently selected fields by the user,
-     * according to HTML specification
-     * @return {undefined}
-     */
-    setSelectedRunsFields(selectedOptions) {
-        this.selectedRunsFields = [];
-        [...selectedOptions].map((selectedOption) => this.selectedRunsFields.push(selectedOption.value));
-        this.notify();
-    }
 
     /**
      * Getter for the trigger values filter Set
@@ -349,11 +279,11 @@ export class RunsOverviewModel extends OverviewPageModel {
      * @return {RemoteData} the remote data of the runs
      */
     get allRuns() {
-        if (this._allRuns.isNotAsked()) {
+        if (this._allRuns$.getCurrent().isNotAsked()) {
             this._fetchAllRunsWithoutPagination();
         }
 
-        return this._allRuns;
+        return this._allRuns$.getCurrent();
     }
 
     /**
@@ -401,20 +331,20 @@ export class RunsOverviewModel extends OverviewPageModel {
      */
     async _fetchAllRunsWithoutPagination() {
         if (this.items.isSuccess() && this.items.payload.length === this._pagination.itemsCount) {
-            this._allRuns = RemoteData.success([...this.items.payload]);
+            this._allRuns$.setCurrent(RemoteData.success([...this.items.payload]));
             this.notify();
             return;
         }
-        this._allRuns = RemoteData.loading();
+        this._allRuns$.setCurrent(RemoteData.loading());
         this.notify();
 
         const endpoint = this.getRootEndpoint();
 
         try {
             const { items } = await getRemoteDataSlice(endpoint);
-            this._allRuns = RemoteData.success(items);
+            this._allRuns$.setCurrent(RemoteData.success(items));
         } catch (errors) {
-            this._allRuns = RemoteData.failure(errors);
+            this._allRuns$.setCurrent(RemoteData.failure(errors));
         }
 
         this.notify();

--- a/lib/public/views/Runs/Overview/exportRunsTriggerAndModal.js
+++ b/lib/public/views/Runs/Overview/exportRunsTriggerAndModal.js
@@ -25,8 +25,9 @@ import { runsActiveColumns } from '../ActiveColumns/runsActiveColumns.js';
  */
 const exportForm = (runsOverviewModel, runs, modalHandler) => {
     const exportTypes = ['JSON', 'CSV'];
-    const selectedRunsFields = runsOverviewModel.getSelectedRunsFields() || [];
-    const selectedExportType = runsOverviewModel.getSelectedExportType() || exportTypes[0];
+    const { exportModel } = runsOverviewModel;
+    const selectedRunsFields = exportModel.getSelectedFields() || [];
+    const selectedExportType = exportModel.getSelectedExportType() || exportTypes[0];
     const runsFields = Object.keys(runsActiveColumns);
     const enabled = selectedRunsFields.length > 0;
 
@@ -46,7 +47,7 @@ const exportForm = (runsOverviewModel, runs, modalHandler) => {
         h('select#fields.form-control', {
             style: 'min-height: 20rem;',
             multiple: true,
-            onchange: ({ target }) => runsOverviewModel.setSelectedRunsFields(target.selectedOptions),
+            onchange: ({ target }) => exportModel.setSelectedFields(target.selectedOptions),
         }, [
             ...runsFields
                 .filter((name) => !['id', 'actions'].includes(name))
@@ -66,7 +67,7 @@ const exportForm = (runsOverviewModel, runs, modalHandler) => {
                     value: exportType,
                     checked: selectedExportType.length ? selectedExportType.includes(exportType) : false,
                     name: 'runs-export-type',
-                    onclick: () => runsOverviewModel.setSelectedExportType(exportType),
+                    onclick: () => exportModel.setSelectedExportType(exportType),
                 }),
                 h('label.form-check-label', {
                     for: id,
@@ -76,10 +77,10 @@ const exportForm = (runsOverviewModel, runs, modalHandler) => {
         h('button.shadow-level1.btn.btn-success.mt2#send', {
             disabled: !enabled,
             onclick: async () => {
-                await runsOverviewModel.createRunsExport(
-                    runs,
+                await exportModel.createExport(
                     'runs',
                     runsActiveColumns,
+                    (err) => runsOverviewModel._observableItems.setCurrent(err),
                 );
                 modalHandler.dismiss();
             },

--- a/lib/public/views/Runs/RunPerDataPass/RunsPerDataPassOverviewModel.js
+++ b/lib/public/views/Runs/RunPerDataPass/RunsPerDataPassOverviewModel.js
@@ -22,6 +22,7 @@ import { SkimmingStage } from '../../../domain/enums/SkimmingStage.js';
 import { NumericalComparisonFilterModel } from '../../../components/Filters/common/filters/NumericalComparisonFilterModel.js';
 import { RunDetectorsSelectionModel } from '../RunDetectorsSelectionModel.js';
 import { jsonFetch } from '../../../utilities/fetch/jsonFetch.js';
+import { RunsPerDataPassExportModel } from '../../../models/RunsPerDataPassExportModel.js';
 
 /**
  * Runs Per Data Pass overview model
@@ -33,6 +34,8 @@ export class RunsPerDataPassOverviewModel extends FixedPdpBeamTypeRunsOverviewMo
      */
     constructor(model) {
         super(model);
+        this.exportModel = new RunsPerDataPassExportModel(this._observableItems, this._dataPassId);
+        this.exportModel.bubbleTo(this);
         this._detectors$ = detectorsProvider.qc$;
         this._detectors$.bubbleTo(this);
         this._dataPass = new ObservableData(RemoteData.notAsked());
@@ -281,6 +284,7 @@ export class RunsPerDataPassOverviewModel extends FixedPdpBeamTypeRunsOverviewMo
      */
     set dataPassId(dataPassId) {
         this._dataPassId = dataPassId;
+        this.exportModel?.setDataPassId(dataPassId);
     }
 
     /**


### PR DESCRIPTION
## Summary
- extract export logic to new `OverviewExportModel`
- use the export model from `OverviewPageModel`
- update runs export UI to rely on the new model
- make export model use `ObservableData` as its item source
- fetch QC flags when exporting Runs Per Data Pass

## Testing
- `npm test` *(fails: mocha not found)*
- `npm run lint` *(fails: cannot find module 'globals')*


------
https://chatgpt.com/codex/tasks/task_e_6888cc8bc00883239dcaf63783ebffde